### PR TITLE
Version 3.5.4: Fix for PostgreSQL v13.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.4] - 2024-03-21
+
+### Changed in 3.5.4
+
+- Updated `senzing-listener` dependency to version `0.5.7` and `data-mart-replicator`
+  to version `1.1.2` to get fix for PostgreSQL v13.x when using 
+  `com.senzing.listener.communication.sql.PostgreSQLClient`.
+
 ## [3.5.3] - 2024-03-20
 
 ### Changed in 3.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.3] - 2024-03-20
+
+### Changed in 3.5.3
+
+- Added support for PostgreSQL v13.x by changing changing `CREATE OR REPLACE TRIGGER`
+  to `DROP TRIGGER` and `CREATE TRIGGER`.
+
 ## [3.5.2] - 2024-03-06
 
 ### Changed in 3.5.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2024-03-18
 
 LABEL Name="senzing/senzing-poc-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.5.3"
+      Version="3.5.4"
 
 # Set environment variables.
 
@@ -51,7 +51,7 @@ ENV REFRESHED_AT=2024-03-18
 
 LABEL Name="senzing/senzing-poc-server" \
       Maintainer="support@senzing.com" \
-      Version="3.5.3"
+      Version="3.5.4"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2024-03-18
 
 LABEL Name="senzing/senzing-poc-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.5.2"
+      Version="3.5.3"
 
 # Set environment variables.
 
@@ -51,7 +51,7 @@ ENV REFRESHED_AT=2024-03-18
 
 LABEL Name="senzing/senzing-poc-server" \
       Maintainer="support@senzing.com" \
-      Version="3.5.2"
+      Version="3.5.3"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.5.2</version>
+  <version>3.5.3</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-listener</artifactId>
-      <version>0.5.5</version>
+      <version>0.5.6</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>data-mart-replicator</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1</version>
     </dependency>    
     <dependency>
      <groupId>org.xerial</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.5.3</version>
+  <version>3.5.4</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-listener</artifactId>
-      <version>0.5.6</version>
+      <version>0.5.7</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>data-mart-replicator</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.2</version>
     </dependency>    
     <dependency>
      <groupId>org.xerial</groupId>


### PR DESCRIPTION
- Updated `senzing-listener` dependency to version `0.5.7` and `data-mart-replicator` to version `1.1.2` to get fix for PostgreSQL v13.x when using `com.senzing.listener.communication.sql.PostgreSQLClient`.
