### PR TITLE
Removed direct dependency on senzing-listener for release version 3.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.5] - 2024-12-12
+
+### Changed in 3.6.5
+
+- Removed `senzing-listener` dependency since it is now part of `data-mart-replicator`
+
 ## [3.6.4] - 2024-12-06
 
 ### Changed in 3.6.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV REFRESHED_AT=2024-06-24
 
 LABEL Name="senzing/senzing-poc-server" \
   Maintainer="support@senzing.com" \
-  Version="3.6.4"
+  Version="3.6.5"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.6.4</version>
+  <version>3.6.5</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -20,13 +20,8 @@
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
-      <artifactId>senzing-listener</artifactId>
-      <version>1.0.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.senzing</groupId>
       <artifactId>data-mart-replicator</artifactId>
-      <version>1.1.6</version>
+      <version>1.2.0</version>
     </dependency>    
     <dependency>
      <groupId>org.xerial</groupId>


### PR DESCRIPTION
Removed direct dependency on `sensing-listener` since this code is now part of `data-mart-replicator`.